### PR TITLE
SQLite to Mysql not same column order fix

### DIFF
--- a/sqlitedump.sh
+++ b/sqlitedump.sh
@@ -5,5 +5,6 @@ for t in $TABLES; do
     echo "TRUNCATE TABLE $t;"
 done
 for t in $TABLES; do
-    echo -e ".mode insert $t\nselect * from $t;"  
-done | sqlite3 $DB | sed -e 's/\\[rnut"]/\\&/g'
+    column="$(sqlite3 $DB ".schema $t" | sed ':a;N;$!ba;s/\n//g;s/;/;\n/g' | grep "CREATE TABLE" | cut -d\( -f2- | tr ',' '\n' | sed 's/"/`/g' | sed -E 's/^ +//g' | cut -d\  -f1 | sed  ':a;N;$!ba;s/\n/,/g')"
+    echo -e ".mode insert $t($column)\nselect * from $t;"  
+done | sqlite3 $DB | sed -e 's/\\[rnut"]/\\&/g' | sed -E 's/^INSERT INTO "([a-z_][a-z_0-9]*\(([a-z_`][a-z_0-9`]*,?)+\))"/INSERT INTO \1/g'


### PR DESCRIPTION
In Grafana 9 , the column order is not the same between SQLite and MySQL, therefore column name is added for the SQl INSERT INTO instructions